### PR TITLE
fix weather API call's query params

### DIFF
--- a/controllers/shot.js
+++ b/controllers/shot.js
@@ -65,7 +65,7 @@ module.exports = {
               weight: 38,
               time: 25,
               roastDate: new Date("2023-01-22T00:00:00.000Z")}
-            let weatherData = await superagent.get(`http://api.weatherapi.com/v1/forecast.json?key=${process.env.WEATHERKEY}q=${process.env.ZIP}&days=1&aqi=no&alerts=no`)
+            let weatherData = await superagent.get(`https://api.weatherapi.com/v1/forecast.json?key=${process.env.WEATHERKEY}&q=${process.env.ZIP}&days=1&aqi=no&alerts=no`)
             console.log(weatherData._body)
             console.log(shotData)
             res.render('shot.ejs', { user: req.user, localWeather: weatherData._body.current, lastShot: lastShot })


### PR DESCRIPTION
When running the application locally, I was getting an API error:
<img width="662" alt="image" src="https://github.com/cpmcclure/barclime/assets/4733753/51012b02-ce84-456b-8bb9-f7c814199ce3">

It looks like we were missing an '&' between query parameters which caused the call to think our API key included the 'q' parameter. 